### PR TITLE
Add Kubernetes deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .env
 Makefile
 *.mk
+secret.yaml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.env
+Makefile
+*.mk

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 Makefile
 *.mk
 secret.yaml
+.git/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 venv
+secret.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN apk add --no-cache tzdata \
 COPY requirements.txt /usr/src/app/requirements.txt
 WORKDIR /usr/src/app
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . /usr/src/app
+COPY cloudflare.py /usr/src/app/
 
 CMD ["./cloudflare.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
-FROM python:2-onbuild
+FROM python:2-alpine
+
+COPY requirements.txt /usr/src/app/requirements.txt
+WORKDIR /usr/src/app
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /usr/src/app
 
 CMD ["./cloudflare.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:2-alpine
 
+RUN apk add --no-cache tzdata \
+  && ln -sf /usr/share/zoneinfo/Asia/Singapore /etc/localtime
+
 COPY requirements.txt /usr/src/app/requirements.txt
 WORKDIR /usr/src/app
 RUN pip install --no-cache-dir -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+SHELL=/bin/bash
+DIR_NAME ?= $(notdir $(shell pwd))
+
+DOCKER_REGISTRY ?= registry.honestbee.com/
+SHORT_NAME ?= ${DIR_NAME}
+BUILD_TAG ?= git-$(shell git rev-parse --short HEAD)
+IMAGE_PREFIX ?= honestbee
+
+include help.mk
+include versioning.mk
+
+## build docker images
+build: docker-build
+
+## push docker images
+push: docker-push
+
+## install service on a kubernetes cluster
+install: kube-apply
+
+## delete service from a kubernetes cluster
+delete: kube-delete
+
+## run all containers in stack locally
+run: docker-run docker-ports
+
+## get a shell into the built image locally
+shell: docker-shell
+
+## list container port mappings
+ports: docker-ports
+
+## stop & remove all containers in stack
+stop: docker-stop
+
+## follow container logs
+logs: docker-logs
+
+## attach terminal to container
+attach: docker-attach
+
+docker-build:
+	docker build --rm=true --tag=${IMAGE} .
+	docker tag ${IMAGE} ${MUTABLE_IMAGE}
+
+docker-logs:
+	docker logs -f `docker ps -lqf ancestor=${MUTABLE_IMAGE}`
+
+docker-run: #docker-build
+	docker run -d -P --env-file .env --name ${SHORT_NAME} ${MUTABLE_IMAGE}
+
+docker-shell: #docker-build
+	docker run -it --rm -v ${PWD}:/usr/src/app --entrypoint /bin/bash ${MUTABLE_IMAGE}
+
+docker-ports:
+	@echo "Exposed Ports:"
+	@docker inspect --format='{{range $$p, $$conf := .NetworkSettings.Ports}} {{$$p}} -> {{(index $$conf 0).HostPort}} {{end}}' `docker ps -lqf ancestor=${MUTABLE_IMAGE}`
+
+docker-attach:
+	@echo "Detach with ^p ^q"
+	docker attach `docker ps -lqf ancestor=${MUTABLE_IMAGE}`
+
+docker-stop:
+	docker stop ${SHORT_NAME} && docker rm ${SHORT_NAME}
+
+kube-delete:
+	-kubectl delete -f manifests/${SHORT_NAME}-bundle.yaml
+
+kube-apply:
+	-kubectl apply -f manifests/${SHORT_NAME}-bundle.yaml
+

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ docker-run: #docker-build
 	docker run -d -P --env-file .env --name ${SHORT_NAME} ${MUTABLE_IMAGE}
 
 docker-shell: #docker-build
-	docker run -it --rm -v ${PWD}:/usr/src/app --entrypoint /bin/bash ${MUTABLE_IMAGE}
+	docker run -it --rm -v ${PWD}:/usr/src/app --env-file .env --entrypoint /bin/sh ${MUTABLE_IMAGE}
 
 docker-ports:
 	@echo "Exposed Ports:"

--- a/README.md
+++ b/README.md
@@ -16,17 +16,49 @@ sending timestamps.
 Populate the following variables in the environment or a .env file.
 
 
-  *DATADOG_API_KEY*: Datadog API Key
-  *DATADOG_APP_KEY*: Datadog App Key
-  *STATS_KEY_PREFIX*: Prefix for the metrics sent in Datadog.
-  *AUTH_EMAIL*: Cloudflare auth email
-  *AUTH_KEY*: Cloudflare auth key
-  *ZONE*: Cloudflare Zone
+  `DATADOG_API_KEY`: Datadog API Key
+
+  `DATADOG_APP_KEY`: Datadog App Key
+
+  `STATS_KEY_PREFIX`: Prefix for the metrics sent in Datadog.
+
+  `AUTH_EMAIL`: Cloudflare auth email
+
+  `AUTH_KEY`: Cloudflare auth key
+
+  `SINCE`: Cloudflare Analytics (based on Plan)
+
+  * Free plan can only get 1 hour period analytics (Since: -1440)
+  * Pro & Business plans can only get 15 min. periods (Since: -360)
+  * Enterprise can get up to 1 min. period analytics (Since: -30)
+
+  `ZONE`: Cloudflare Zone
+
+How to get Cloudflare zone id:
+
+Populate `AUTH_EMAIL` and `AUTH_KEY` parameters, then:
+```
+make build
+make shell
+apk add --no-cache jq curl
+curl https://api.cloudflare.com/client/v4/zones?name=example.com \
+ -H "X-Auth-Email: $AUTH_EMAIL" -H "X-Auth-Key: $AUTH_KEY" \
+ | jq -r .result[].id
+```
+
 
 
 ### Shell
 
-Install:
+Using Docker:
+
+```
+make build
+make shell
+./cloudflare.py
+```
+
+Using virtualenv:
 
 ```shell
 virtualenv venv
@@ -42,4 +74,7 @@ Run:
 
 ### Docker
 
-docker run --env-file .env mozorg/cloudflare-datadog-sync
+```
+make build
+make run
+```

--- a/cloudflare.py
+++ b/cloudflare.py
@@ -14,8 +14,10 @@ from dateutil import tz
 ZONE = config('ZONE')
 AUTH_EMAIL = config('AUTH_EMAIL')
 AUTH_KEY = config('AUTH_KEY')
+SINCE = config('SINCE')
 URL = ('https://api.cloudflare.com/client/v4/zones/'
-       '{}/analytics/dashboard?since=-30'.format(ZONE))
+       '{zone}/analytics/dashboard?since={since}'
+       .format(zone=ZONE,since=SINCE))
 DEAD_MANS_SNITCH_URL = config('DEAD_MANS_SNITCH_URL', None)
 STATS_KEY_PREFIX = config('STATS_KEY_PREFIX', default='cloudflare')
 if not STATS_KEY_PREFIX.endswith('.'):

--- a/env2secret.py
+++ b/env2secret.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import os,yaml,argparse
+from base64 import b64encode
+
+parser = argparse.ArgumentParser(description="convert .env to k8s secret")
+parser.add_argument("-i","--input-file", default=".env",
+        help=".env file to parse (default=./.env)")
+parser.add_argument("-o","--output-file",default="secret.yaml",
+        help="yaml file to generate (default=./secret.yaml)")
+parser.add_argument("-s","--secret-name",default="mysecret",
+        help="name for secret (default=mysecret)")
+args = parser.parse_args()
+
+secret = {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {
+        "name": args.secret_name
+        },
+    "type": "Opaque",
+    "data": {}
+    }
+# add secrets from envfile
+if not os.path.exists(args.input_file):
+    print("{filename} not found".format(filename=args.input_file))
+else:
+    with open(args.input_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            k,v = line.split('=',1)
+            v = v.strip()
+            k = k.lower().replace('_','-')
+            k = ''.join(e for e in k if (e.isalnum() or e == '-'))
+            secret['data'][k]=b64encode(v)
+# dump secret to yaml
+with open(args.output_file,'w') as out:
+    yaml.dump(secret,out,default_flow_style=False)

--- a/help.mk
+++ b/help.mk
@@ -1,0 +1,17 @@
+## display this help text
+help:
+	$(info Available targets)
+	@awk '/^[a-zA-Z\-\_0-9]+:/ {                    \
+		nb = sub( /^## /, "", helpMsg );              \
+		if(nb == 0) {                                 \
+			helpMsg = $$0;                              \
+			nb = sub( /^[^:]*:.* ## /, "", helpMsg );   \
+		}                                             \
+		if (nb)                                       \
+			print  $$1 "\t" helpMsg;                    \
+	}                                               \
+	{ helpMsg = $$0 }'                              \
+	$(MAKEFILE_LIST) | column -ts $$'\t' |          \
+	grep --color '^[^ ]*'
+
+.PHONY: help

--- a/k8s-bundle.yaml
+++ b/k8s-bundle.yaml
@@ -1,0 +1,59 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: dd-cf-agent
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: dd-cf-agent
+    spec:
+      containers:
+      - name: dd-cf-agent
+        image: registry.honestbee.com/honestbee/cloudflare-datadog:latest
+        imagePullPolicy: Always
+        env:
+        - name: "DATADOG_API_KEY"
+          valueFrom: 
+            secretKeyRef:
+              name: dd-cf-agent-secret
+              key: datadog-api-key
+        - name: "DATADOG_APP_KEY"
+          valueFrom: 
+            secretKeyRef:
+              name: dd-cf-agent-secret
+              key: datadog-app-key
+        - name: "STATS_KEY_PREFIX"
+          valueFrom: 
+            secretKeyRef:
+              name: dd-cf-agent-secret
+              key: stats-key-prefix
+        - name: "AUTH_EMAIL"
+          valueFrom: 
+            secretKeyRef:
+              name: dd-cf-agent-secret
+              key: auth-email
+        - name: "AUTH_KEY"
+          valueFrom: 
+            secretKeyRef:
+              name: dd-cf-agent-secret
+              key: auth-key
+        - name: "ZONE"
+          valueFrom: 
+            secretKeyRef:
+              name: dd-cf-agent-secret
+              key: zone
+        - name: "SINCE"
+          valueFrom: 
+            secretKeyRef:
+              name: dd-cf-agent-secret
+              key: since
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+      imagePullSecrets: 
+      - name: honestbee-registry 
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 APScheduler==3.0.4
 requests==2.10.0
-datadog==0.12.0
+datadog==0.14.0
 python-decouple==3.0
 python-dateutil==2.5.3

--- a/versioning.mk
+++ b/versioning.mk
@@ -1,0 +1,26 @@
+MUTABLE_VERSION ?= latest
+DEV_TAG ?= dev
+VERSION ?= git-$(shell git rev-parse --short HEAD)
+
+IMAGE := ${DOCKER_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
+DEV_IMAGE := ${DOCKER_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${DEV_TAG}
+MUTABLE_IMAGE := ${DOCKER_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${MUTABLE_VERSION}
+
+## show image tags
+info:
+	@echo "Build tag:      ${VERSION}"
+	@echo "Registry:       ${DOCKER_REGISTRY}"
+	@echo "Immutable tag:  ${IMAGE}"
+	@echo "Dev tag:        ${DEV_IMAGE}"
+	@echo "Mutable tag:    ${MUTABLE_IMAGE}"
+
+.PHONY: docker-push
+docker-push: docker-mutable-push docker-immutable-push
+
+.PHONY: docker-immutable-push
+docker-immutable-push:
+	docker push ${IMAGE}
+
+.PHONY: docker-mutable-push
+docker-mutable-push:
+	docker push ${MUTABLE_IMAGE}


### PR DESCRIPTION
- Reduce docker image from 660MB to 80MB by basing of alpine
- Add ability to control analytics range as our cloudflare plan can only get up to 15 minute analytics (original script always tried to get 1 min)
- Add python script to convert .env file to kubernetes secrets
- Add deployment manifest (no secrets in repo, all secrets are added as environment variables from the namespace secret
- Add README instructions on how to deploy to kubernetes and how to troubleshoot the deployment